### PR TITLE
resolve 'notarray' error

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -581,3 +581,9 @@ var mainApp = angular.module('dataMovingApp', [
     $scope.fetchRuns(false);
   }]
 )
+
+.filter('sortBy', function() {
+  return function(items, field) {
+	  return _.sortBy(items, [field]);
+  };
+})

--- a/app/templates/pipeDetails.monitoring.html
+++ b/app/templates/pipeDetails.monitoring.html
@@ -72,7 +72,7 @@
 				<th>Status</th>
 			</thead>
 			<tbody>
-				<tr ng-repeat="stat in activeRun.tableStats | orderBy:'tableName'">
+				<tr ng-repeat="stat in activeRun.tableStats | sortBy:'tableName'">
 					<td>{{stat.tableName}}</td>
 					<td><span class="piperecord">{{stat.numRecords | number}}</span></td>
 					<td>{{stat.errors[0].message}}</td>


### PR DESCRIPTION
the orderBy angular filter only accepts arrays. starting with angular 1.5.0, it throws a 'notarray' error if what is passed to it is not an array. prior to 1.5.0, it would just return the same passed object back