### PR TITLE
add debug switch for pipe run logging

### DIFF
--- a/server/pipeRunStats.js
+++ b/server/pipeRunStats.js
@@ -9,7 +9,8 @@ var moment = require("moment");
 var pipesSDK = require('simple-data-pipe-sdk');
 var pipesDb = pipesSDK.pipesDb;
 var _ = require("lodash");
-var global = require("bluemix-helper-config").global;
+var bluemixHelperConfig = require("bluemix-helper-config");
+var global = bluemixHelperConfig.global;
 
 /**
  * PipeRunStats class
@@ -17,7 +18,16 @@ var global = require("bluemix-helper-config").global;
  */
 function pipeRunStats(pipe, steps, callback){
 	this.pipe = pipe;
-	var logger = this.logger = global.getLogger("pipesRun");
+	var logger = this.logger = global.getLogger("sdp_pipe_run");
+
+	var debug_env_var = bluemixHelperConfig.configManager.get('DEBUG') || '';
+	if((debug_env_var.match(/^[\s]*\*[\s]*$/i)) || (debug_env_var.match(/[\s,]+\*[\s,]*/i)) || (debug_env_var.match(/[\s]*sdp_pipe_run[\s]*/i))) {
+		// enable lowest level of logging for data pipe runs if the DEBUG environment variable is set
+		logger.level("trace");
+	}
+
+	logger.info('Setting Simple Data Pipe run log level to ' + logger.level());
+
 	var runDoc = this.runDoc = {
 		type : "run",
 		connectorId : pipe.connectorId,

--- a/server/pipeRunStats.js
+++ b/server/pipeRunStats.js
@@ -25,8 +25,11 @@ function pipeRunStats(pipe, steps, callback){
 		// enable lowest level of logging for data pipe runs if the DEBUG environment variable is set
 		logger.level("trace");
 	}
+	else {
+		logger.level("info");
+	}
 
-	logger.info('Setting Simple Data Pipe run log level to ' + logger.level());
+	logger.info('Simple Data Pipe run log level is ' + logger.level());
 
 	var runDoc = this.runDoc = {
 		type : "run",


### PR DESCRIPTION
Low level logging for data pipe runs is now enabled if environment variable DEBUG (_case matters_) is set to `*` or contains the string `sdp_pipe_run`, following the convention defined in https://www.npmjs.com/package/debug. The default log level remains `info`.