### PR TITLE
resolve log attachment issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-data-pipe",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Tool for loading cloud data (e.g. from salesforce) into Cloudant.",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
I41: Attachment of pipe run log fails fails due to document update conflicts. We are now waiting until all queued document updates have been saved before attempting to attach the log. If pending updates are not resolved within 10 minutes no attempt is made to attach the file.