### PR TITLE
i41 use 8082 as default port

### DIFF
--- a/server.js
+++ b/server.js
@@ -56,7 +56,7 @@ if ('development' === env || 'test' === env) {
 	app.use(errorHandler()); // Error handler - has to be last
 }
 
-var port = process.env.VCAP_APP_PORT || configManager.get("DEV_PORT") || 443
+var port = process.env.VCAP_APP_PORT || configManager.get("DEV_PORT") || 8082;
 if (!process.env.VCAP_APP_HOST){
 	//Running locally. Salesforce requires authCallbacks to use SSL by default
 	global.appHost = "https://127.0.0.1";


### PR DESCRIPTION
Default to 8082 if environment variables VCAP_APP_PORT and DEV_PORT are not defined.