### PR TITLE
Update to new Bluemix Plan names

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Complete these steps first if you have not already:
 
 Create a Cloudant service within Bluemix if one has not already been created:
 
-    $ cf create-service cloudantNoSQLDB Shared sdp-cloudant-service
+    $ cf create-service cloudantNoSQLDB Lite sdp-cloudant-service
 
 Create a Single Sign On (SSO) service within Bluemix if one has not already been created:
 
-    $ cf create-service SingleSignOn standard pipes-sso-service
+    $ cf create-service SingleSignOn professional pipes-sso-service
 
 ### Deploying
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,10 +2,10 @@
 declared-services:
   sdp-cloudant-service:
     label: cloudantNoSQLDB
-    plan: Shared
+    plan: Lite
   pipes-sso-service:
     label: SingleSignOn
-    plan: standard
+    plan: professional
 applications:
 - name: simple-data-pipe
   memory: 512M


### PR DESCRIPTION
I had problems deploying to bluemix with the magic button and when I tried to follow the manual steps, I found that some of the plan names had changed in Bluemix.  This branch includes changes for the README which contains the manual steps and the manifest file.

_(note that the SSO service is no longer free)_